### PR TITLE
don't request metadata on pagination

### DIFF
--- a/frontend/src/components/organisms/ListViewTable/ListViewTable.js
+++ b/frontend/src/components/organisms/ListViewTable/ListViewTable.js
@@ -98,6 +98,7 @@ class ListViewTable extends Component {
         const newPayload = this.state.payload;
         newPayload.last = (page * pageSize);
         newPayload.first = newPayload.last - pageSize + 1;
+        newPayload.metadata_required = false;
         const response = await ctgov.post('search_studies', newPayload);
         log.info(response.data);
         this.setState((prevState) => {


### PR DESCRIPTION
Calling search_studies with metadata_required=true takes 10 seconds, so do not call this on the pagination calls.